### PR TITLE
Update common-issues.md

### DIFF
--- a/docs/users/common-issues.md
+++ b/docs/users/common-issues.md
@@ -40,4 +40,4 @@ This issue caused by option "throw-keyids" which isn't supported by OpenKeychain
 The developers of GnuPG introduced a non-standard modification to OpenPGP which results in keys generated with recent versions of GnuPG not being compatible with other OpenPGP implementations, including the one used by Android Password Store. The app will attempt to detect this both in your PGP key as well as password files and warn about this incompatibility. To fix this, you can edit your key to remove the non-standard AEAD feature and re-encrypt the store.
 
 1. Run `gpg --edit-key <key id>`, followed by `setpref SHA512 SHA384 SHA256 SHA224 SHA1 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed` and `quit` to fix your key.
-2. Run `pass init <key id>` to re-encrypt your password store and fix your password files.
+2. Run `pass init <key id>` to re-encrypt your password store and fix your password files. To force re-encryption of password files, you may need to run `pass init` with a different key and then `pass init` with the original key. 


### PR DESCRIPTION
As of pass 1.7.4 I had to use a second key and re-init back to the original to force re-encryption. Finally figured this out after wondering why nothing changed (since the key ID didn't change, I didn't know if the key had changed -- apparently it did and kept the same ID, because reencrypting fixed the android app).